### PR TITLE
Fix error message: 'capnp.node.node' -> 'capnp.node'

### DIFF
--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -40,7 +40,7 @@ try {
   } catch (ex) {
     // Give up.
     throw new Error(
-        "`" + modPath+ ".node` is missing. Try reinstalling `node-capnp`?");
+        "`capnp.node` is missing. Try reinstalling `node-capnp`?");
   }
 }
 


### PR DESCRIPTION
Currently the error displays as "Error: `./capnp.node.node` is missing.".