### PR TITLE
Fix the build process.

### DIFF
--- a/build.js
+++ b/build.js
@@ -76,6 +76,7 @@ function build() {
 		process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp',
 		['rebuild'].concat(args),
 		{customFds: [0, 1, 2]})
+	.on('close', function(){ afterBuild(); })
 	.on('exit', function(err) {
 		if (err) {
 			if (err === 127) {
@@ -88,7 +89,6 @@ function build() {
 			}
 			return process.exit(err);
 		}
-		afterBuild();
 	});
 }
 


### PR DESCRIPTION
The build fails because we are trying to rename a file that's not there yet since some of the stdio streams are still open when the `exit` event fires. With `node-gyp:6.0.1` this fix is not needed but the version that comes bundled with `node:v10` is `node-gyp:5.0.5`