### PR TITLE
Bump version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "capnp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A wrapper for the C++ Cap'n Proto library",
-  "keywords": [ "capnproto", "serialization" ],
+  "keywords": [
+    "capnproto",
+    "serialization"
+  ],
   "homepage": "http://capnproto.org",
   "author": {
     "name": "Kenton Varda",
@@ -15,7 +18,6 @@
       "email": "jparyani@gmail.com"
     }
   ],
-
   "main": "src/node-capnp/capnp.js",
   "scripts": {
     "install": "node ./build.js",


### PR DESCRIPTION
I just published this to the npm registry, we should probably update the
version in the git repo too.

It seems to work on node 12, though node 10 is still failing. I actually
*can* reproduce the failures locally if:

- I start a fresh npm project and do `npm install
  `/path/to/node-canpnp/src`
- The working directory for `node-capnp` is clean.

I may try to troubleshoot this more later. Perhaps we should unpublish,
but having a version that works on node 12 is possibly an improvement,
so maybe not...

Npm insisted that 0.4.0 already existed and was refusing to re-publish
it (I assume there was a deleted failed attempt), so I had to bump the
version to get it to work.

Note that there are some formatting changes too, npm did automatically.