### PR TITLE
More defensive/sensible handling of a case that probably can't happen.

### DIFF
--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -194,7 +194,8 @@ private:
   }
 
   static void doRun(uv_timer_t* handle) {
-    UvEventPort* self = handle == nullptr ? nullptr : reinterpret_cast<UvEventPort*>(handle->data);
+    KJ_ASSERT(handle != nullptr);
+    UvEventPort* self = reinterpret_cast<UvEventPort*>(handle->data);
     self->run();
   }
 };


### PR DESCRIPTION
I found this by running clang-analyzer. With the previous version of the
code, if `handler` is null, then we assign `self = nullptr` and then
immediately call a method on it.

I'm pretty sure this can't actually happen -- I don't think
`uv_timer_start` will ever pass nullptr to the callback -- but the logic
is obviously bogus so let's replace it with something defensive.