### PR TITLE
Add a very minimal typescript declaration file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     }
   ],
   "main": "src/node-capnp/capnp.js",
+  "types": "src/node-capnp/capnp.d.ts",
   "scripts": {
     "install": "node ./build.js",
     "test": "node src/node-capnp/capnp-test.js"

--- a/src/node-capnp/capnp.d.ts
+++ b/src/node-capnp/capnp.d.ts
@@ -1,0 +1,10 @@
+declare module Capnp {
+  type Id = string;
+
+  abstract class Schema<T> {
+    typeId: Id;
+  }
+
+  function parse<T>(type: Schema<T>, buffer: Buffer): T;
+}
+export default Capnp;


### PR DESCRIPTION
Background: I'm working on a compiler plugin to generate tyepscript declaration files to work with node-capnp:

https://github.com/zenhack/capnpc-node-typescript

This PR adds the beginnings of declaration file for the library itself. It is enough that the compiler plugin itself type checks, but obviously is missing most of the API.

From looking at `capnp.js`, I see that `parse` takes an extra optional `options` argument, but this isn't mentioned in the docs anywhere so I left it out of the interface for now.