### PR TITLE
Add a typescript declaration file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     }
   ],
   "main": "src/node-capnp/capnp.js",
+  "types": "src/node-capnp/capnp.d.ts",
   "scripts": {
     "install": "node ./build.js",
     "test": "node src/node-capnp/capnp-test.js"

--- a/src/node-capnp/capnp.d.ts
+++ b/src/node-capnp/capnp.d.ts
@@ -1,0 +1,35 @@
+declare module Capnp {
+  type Id = string;
+
+  abstract class StructSchema<Builder, Reader> {
+    typeId: Id;
+  }
+
+  abstract class InterfaceSchema<Server, Client> {
+    typeId: Id;
+  }
+
+  interface AnyServer {
+    close?: () => void;
+  }
+
+  interface AnyClient {
+    close(): void;
+    closed: boolean;
+    castAs<Server, Client>(schema: InterfaceSchema<Server, Client>): Client;
+  }
+
+  const Capability: {
+    new<Server, Client>(server: Server, schema: InterfaceSchema<Server, Client>): Client;
+  }
+
+  abstract class Connection {
+    restore<Server, Client>(exportName: string, type: InterfaceSchema<Server, Client>): Client;
+    close(): void;
+  }
+
+  function parse<Builder, Reader>(type: StructSchema<Builder, Reader>, buffer: Buffer): Reader;
+  function serialize<Builder, Reader>(type: StructSchema<Builder, Reader>, reader: Reader): Buffer;
+  function connect(addr: string): Connection;
+}
+export default Capnp;


### PR DESCRIPTION
This covers most of the API that is documented in the README, though I
see that there are some things exposed in `capnp.js` but not documented
-- the declaration file does not currently cover those.

This is designed to work with the output of:

    https://github.com/zenhack/capnpc-node-typescript

...which is nearing completion.

---

This is more complete than my previous pr (#61).

@kentonv, one thing I'm still fussing with with the code generator plugin: typescript doesn't understand importSystem() and friends, and I've had trouble getting it to understand require() also (it seems to want es6 style imports). So to work around this the code generator actually generates a javascript wrapper module like:

```javascript
// capnp/schema.capnp.js
import $Capnp from "capnp";
const $tmp = $Capnp.importSystem("capnp/schema.capnp");
export default $tmp
```

...in order to hide the dynamic import from tsc. It then generates a declaration file for the wrapper module.

This works, but in generated code means in order for node to find the import `"capnp/schema.capnp.js"`, the wrapper module must be somewhere were that path will resolve to it -- and I can't figure out a way to do this without just shipping the generated modules with node-capnp itself. Would you be open to merging the projects?
