### PR TITLE
Add .capnp.js stubs generated by capnpc-node-typescript.

### DIFF
--- a/c++.capnp.js
+++ b/c++.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/c++.capnp");

--- a/persistent.capnp.js
+++ b/persistent.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/persistent.capnp");

--- a/rpc-twoparty.capnp.js
+++ b/rpc-twoparty.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/rpc-twoparty.capnp");

--- a/rpc.capnp.js
+++ b/rpc.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/rpc.capnp");

--- a/schema.capnp.js
+++ b/schema.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/schema.capnp");

--- a/stream.capnp.js
+++ b/stream.capnp.js
@@ -1,0 +1,1 @@
+module.exports = require("capnp").importSystem("capnp/stream.capnp");


### PR DESCRIPTION
Per discussion in #62, this allows importing modules to use "normal"
imports, which is important for typescript since it doesn't understand
`capnp.importSystem()` and friends.

We could also merge in the type declarations themselves, but that isn't
strictly necessary, since typescript is built around being able to
supply your own stubs for other libraries. I may do something in that
vein in a follow-on pr, but I want to think a bit about how this
will all fit together.

---

Note that the stubs are at the top level of the repo, which is a bit awkward; it would be nicer to have them in `src/node-capnp`, but I had a hard time figuring out how to get node to find the modules there.